### PR TITLE
Add tini to Docker Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:10-alpine
 
+RUN apk add --no-cache tini
+
 WORKDIR /RTL
 
 COPY . /RTL
@@ -9,5 +11,6 @@ RUN npm install
 
 EXPOSE 3000
 
-#Run the app server
-ENTRYPOINT ["node", "rtl"]
+ENTRYPOINT ["/sbin/tini", "-g", "--"]
+
+CMD ["node", "rtl"]


### PR DESCRIPTION
So when I did my final round of tests before doing a BTCPay PR, I ran into a problem. The good news is that it is a very easy fix.

When I attempted to do a setup/teardown of BTCPay with RTL integrated into the BTCPay docker-compose, the RTL container hung on being stopped. This usually is caused by zombie or other background processes preventing the container from properly stopping.

This is very easily fixable in Docker by simply adding a `tini` Entrypoint; `tini` is basically a very tiny `init` that is great at handling off `SIGTERM` signals from the Docker daemon to the processes inside the container. This PR adds `tini` to the Dockerfile. It only expands the container image by 10kb.

Steps from here:

- [ ] Merge this PR
- [ ] Tag a new release
- [ ] Let me know when the new release is tagged

Once the new release is tagged, I should be able to prepare the PR to use the docker-compose fragment I put together for the BTCPay PR.