### PR TITLE
Have better docker caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ RUN apk add --no-cache tini
 
 WORKDIR /RTL
 
-COPY . /RTL
+COPY package.json /RTL/package.json
+COPY package-lock.json /RTL/package-lock.json
 
 # Install dependencies
 RUN npm install
+
+COPY . /RTL
 
 EXPOSE 3000
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -11,8 +11,13 @@ WORKDIR /RTL
 
 COPY . /RTL
 
+COPY package.json /RTL/package.json
+COPY package-lock.json /RTL/package-lock.json
+
 # Install dependencies
 RUN npm install
+
+COPY . /RTL
 
 FROM arm32v7/node:10-jessie-slim
 


### PR DESCRIPTION
This make sure that when RTL have update without any change of packages, the previous docker cache layer are used, and the udpate fast.