### PR TITLE
Extend the SSL access guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ Open your browser at the following address: http://localhost:3000 to access the 
 * Determine the IP address of your node to access the application.
 E.g. if the IP address of your node is 192.168.0.15 then open your browser at the following address: http://192.168.0.15:3000 to access RTL.
 
-3. Config tweaks for running RTL server and LND on seperate devices on the same network can be found [here](RTL_setups.md).
+3. Config tweaks for running RTL server and LND on separate devices on the same network can be found [here](RTL_setups.md).
 
-4. Any Other setup: **Please be advised, if you are accessing your node remotely via RTL, its critical to encrypt the communication via use of https. You can use solutions like nginx and letsencrypt to setup https access for RTL.**
+4. Any Other setup: **Please be advised, if you are accessing your node remotely via RTL, its critical to encrypt the communication via use of https. You can use solutions like nginx and letsencrypt to setup https access for RTL.** A sample SSL setup guide can be found [here](RTL_SSL_setup.md)
 
 ### <a name="trouble"></a>Troubleshooting
 In case you are running into issues with the application or if you have feedback, feel free to open issues on our github repo.

--- a/RTL_SSL_setup.md
+++ b/RTL_SSL_setup.md
@@ -1,0 +1,34 @@
+### Setup https access for RTL
+
+Forward the ports 80 and 3002 on the router to the device running RTL.  
+Allow the ports through the firewall of the device.
+
+Install Nginx:
+https://www.nginx.com/resources/wiki/start/topics/tutorials/install/
+
+Install certbot to acquire the ssl certificate:
+https://certbot.eff.org
+
+
+Sample configuration to be inserted in the nginx.conf (adjust the path and filename of your certificate and key):
+
+
+    stream {
+            upstream RTL {
+                    server 127.0.0.1:3000;
+            }
+
+            server {
+                    listen 3002 ssl;
+                    proxy_pass RTL;
+
+                    ssl_certificate /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem;
+                    ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem;
+                    ssl_session_cache shared:SSL:1m;
+                    ssl_session_timeout 4h;
+                    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+                    ssl_prefer_server_ciphers on;
+            }
+    }
+
+Restart Nginx with the new configuration and connect to RTL over https on the port 3002.


### PR DESCRIPTION
Add links to install Nginx and certbot.
Sample config for nginx.conf.

Successfully tested on a RaspiBlitz, but kept it generic.