### PR TITLE
rename bitcoind.conf to default bitcoin.conf

### DIFF
--- a/docs/Application_configurations
+++ b/docs/Application_configurations
@@ -25,7 +25,7 @@ menuType=Regular
 theme=dark-blue
 ;Set by RTL
 satsToBTC=false
-;Full path of the bitcoind.conf file including the file name
+;Full path of the bitcoin.conf file including the file name
 bitcoindConfigPath=<>
 ;parameter to turn RTL logging off/on. Allowed values - true, false
 enableLogging=<>


### PR DESCRIPTION
To avoid confusion, 

The default bitcoin configuration name is bitcoin.conf per https://github.com/bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md